### PR TITLE
fix for capistrano stages with useless servers

### DIFF
--- a/lib/toquen/aws.rb
+++ b/lib/toquen/aws.rb
@@ -89,7 +89,7 @@ module Toquen
     def server_details_in(region)
       AWS.config(:access_key_id => @key_id, :secret_access_key => @key, :region => region)
       AWS.memoize do
-        AWS::EC2.new.instances.map do |i|
+        AWS::EC2.new.instances.filter("instance-state-name", "running").map do |i|
           {
             :id => i.tags["Name"],
             :internal_ip => i.private_ip_address,


### PR DESCRIPTION
Instances that are not running get inserted into stages even though they are not accessible, no public dns/ip, resulting in errors on deploy. Simple fix to filter for running instances only on the aws.describe_instances method.

My use case is with background workers. I have 6 worker instances with the "worker" role and at any given moment not all of them may be running. I would still like to deploy to running instances without manually updating the "worker" stage to remove empty servers.
